### PR TITLE
Change 'About Us' to 'About' in navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -27,7 +27,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
               Home
             </a>
             <a href="#about" className="text-foreground hover:text-accent transition-colors">
-              About Us
+              About
             </a>
             <a href="#services" className="text-foreground hover:text-accent transition-colors">
               Services
@@ -69,7 +69,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
                 className="block px-3 py-2 text-foreground hover:text-accent transition-colors"
                 onClick={() => setIsOpen(false)}
               >
-                About Us
+                About
               </a>
               <a
                 href="#services"


### PR DESCRIPTION
## Feature Overview

This PR changes the text of the navbar item from "About Us" to "About" to improve user experience and interface cleanliness.

## Implementation Details

- Changed the text label from "About Us" to "About" in both desktop and mobile navigation components
- Maintained all existing functionality and links
- Made minimal changes to ensure code stability

## Testing Steps

1. Verify the navbar displays "About" instead of "About Us" in desktop view
2. Test the mobile view to ensure "About" is displayed correctly
3. Confirm clicking the "About" link still navigates to the correct section
4. Check responsiveness across different screen sizes

## Related

Feature Request ID: FR-20250823-001