### PR TITLE
Change 'Contact' to 'Contact us' in navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -33,7 +33,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
               Services
             </a>
             <a href="#contact" className="text-foreground hover:text-accent transition-colors">
-              Contact
+              Contact us
             </a>
           </div>
 
@@ -83,7 +83,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
                 className="block px-3 py-2 text-foreground hover:text-accent transition-colors"
                 onClick={() => setIsOpen(false)}
               >
-                Contact
+                Contact us
               </a>
               <div className="flex flex-col space-y-2 px-3 pt-4">
                 <Button variant="ghost" className="justify-start text-foreground hover:text-accent">


### PR DESCRIPTION
## Overview
This PR changes the navigation label from 'Contact' to 'Contact us' in the website's main navigation bar for both desktop and mobile views.

## Implementation Details
- Updated the text in the desktop navigation section
- Updated the text in the mobile navigation section
- Maintained all existing styling and functionality

## Testing
- [x] Verified text appears correctly on the landing page
- [x] Tested on multiple browsers (Chrome, Firefox, Safari, Edge)
- [x] Confirmed proper display on mobile, tablet, and desktop viewports
- [x] Ensured the navigation link still functions correctly

## Related
Implements Feature Request FR-2025-08-23-001