### PR TITLE
Fix typo in navbar: Change 'Contactt' to 'Contact'

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -33,7 +33,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
               Services
             </a>
             <a href="#contact" className="text-foreground hover:text-accent transition-colors">
-              Contactt
+              Contact
             </a>
           </div>
 
@@ -83,7 +83,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
                 className="block px-3 py-2 text-foreground hover:text-accent transition-colors"
                 onClick={() => setIsOpen(false)}
               >
-                Contactt
+                Contact
               </a>
               <div className="flex flex-col space-y-2 px-3 pt-4">
                 <Button variant="ghost" className="justify-start text-foreground hover:text-accent">


### PR DESCRIPTION
## Overview
This PR fixes a typo in the website's navigation bar where "Contact" was misspelled as "Contactt".

## Implementation Details
- Corrected the spelling of "Contactt" to "Contact" in the navbar component
- Fixed the typo in both desktop and mobile navigation sections
- Made minimal changes using surgical text replacements

## Testing
- Verified the corrected spelling appears in the desktop navigation
- Verified the corrected spelling appears in the mobile navigation when expanded
- Confirmed that clicking the "Contact" link still navigates to the correct section
- Tested on different screen sizes to ensure responsive behavior works correctly

## Screenshots
Before: Navigation showed "Contactt"
After: Navigation shows "Contact"

## Related Issue
Addresses the typo correction feature request submitted by Oliver Carmont.