### PR TITLE
Fix: Improve Navbar Text Readability with Darker Background Color

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -10,7 +10,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
   return (
     <nav className={`fixed top-0 left-0 right-0 z-50 ${
   variant === "landing" 
-    ? "bg-orange-500" 
+    ? "bg-gray-900" 
     : "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
 } border-b border-border`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Overview
This PR addresses the readability issue with the navbar by changing its background color from bright orange to a dark grey (almost black) color. The current orange background makes white text difficult to read, especially for users with visual impairments.

## Implementation Details
- Changed the navbar background color from `bg-orange-500` to `bg-gray-900` for the landing page variant
- The new color provides sufficient contrast with white text, meeting WCAG 2.1 AA standards (minimum 4.5:1 contrast ratio)
- The change is minimal and only affects the landing page navbar variant

## Testing
- Verified the new color provides excellent readability for white text
- Tested across different viewport sizes to ensure consistent appearance
- Confirmed the change works well in both light and dark modes
- Checked that all navbar elements remain visually distinct against the new background

## Screenshots
Before: White text on bright orange background (poor contrast)
After: White text on dark grey background (excellent contrast)

## Related Issue
Resolves the issue where "The bright orange color of the navbar makes it hard to read the white text on it."

Requested by: Oliver <olcarmontzaragoza@gmai.com>