### PR TITLE
Fix navbar orange color inconsistency

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -10,7 +10,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
   return (
     <nav className={`fixed top-0 left-0 right-0 z-50 ${
   variant === "landing" 
-    ? "bg-orange-300" 
+    ? "bg-accent" 
     : "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
 } border-b border-border`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Overview
This PR addresses the navbar orange color inconsistency issue (FR-2025-08-23-001) by replacing the hardcoded Tailwind color class with the design system token.

## Problem
The navbar currently uses a hardcoded `bg-orange-300` Tailwind class for its background when in "landing" variant. This creates a visual inconsistency with other orange UI elements across the application that use the design system's orange color through the `bg-accent` or `bg-secondary` classes.

## Solution
Replaced the hardcoded `bg-orange-300` with `bg-accent` to ensure the navbar uses the same orange shade defined in the design system's CSS variables (`--accent: oklch(0.65 0.18 45)`).

## Implementation Details
- Modified `components/navbar.tsx` to use the design token instead of hardcoded color
- Used surgical replacement to make a minimal change to the codebase
- No other changes were required as this was a single-line modification

## Testing
- Verified that the navbar color now matches other orange UI elements
- Checked color contrast for accessibility to ensure text remains readable
- Tested on different screen sizes to ensure consistent appearance
- Verified across Chrome, Firefox, and Safari browsers

## Additional Notes
During implementation, I noticed another hardcoded orange color in `components/feedback-toast.tsx` (using `bg-orange-600` and `hover:bg-orange-700`). This should be addressed in a separate task to maintain complete color consistency throughout the application.

## Related Issues
- FR-2025-08-23-001: Navbar Orange Color Inconsistency