### PR TITLE
Fix navbar typo and color inconsistency

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -10,7 +10,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
   return (
     <nav className={`fixed top-0 left-0 right-0 z-50 ${
   variant === "landing" 
-    ? "bg-red-800" 
+    ? "bg-accent" 
     : "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
 } border-b border-border`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -24,7 +24,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center space-x-8">
             <a href="#home" className="text-foreground hover:text-accent transition-colors">
-              Hzme
+              Home
             </a>
             <a href="/about2" className="text-foreground hover:text-accent transition-colors">
               About
@@ -62,7 +62,7 @@ export function Navbar({ variant }: { variant?: "landing" }) {
                 className="block px-3 py-2 text-foreground hover:text-accent transition-colors"
                 onClick={() => setIsOpen(false)}
               >
-                Hzme
+                Home
               </a>
               <a
                 href="/about2"


### PR DESCRIPTION
## Overview
This PR addresses two issues with the landing page navbar:

1. Fixes a typo in the navigation menu where 'Hzme' is displayed instead of 'Home'
2. Updates the navbar color from red to the site's standard orange theme for consistency

## Implementation Details
- Fixed the text content of the navbar links from 'Hzme' to 'Home' in both desktop and mobile views
- Changed the navbar background color from `bg-red-800` to `bg-accent` to match the site's orange theme
- Used the existing theme system with CSS variables instead of hardcoded colors

## Testing
- Verified the navbar displays 'Home' instead of 'Hzme' in both desktop and mobile views
- Confirmed the navbar color is now orange and matches the site's theme
- Tested across different screen sizes to ensure responsive behavior
- Checked both light and dark modes to ensure proper color contrast

## Related Issues
Feature ID: FR-2025-08-23-001

These changes are minimal and only affect the text and color of the navbar without changing any functionality.